### PR TITLE
Fetch git tags for auto publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Prepare repository
+        run: git fetch --unshallow --tags
+
       - name: Install
         run: npm ci
 


### PR DESCRIPTION
Fixes auto publishing - `auto` needs to be able to see existing tags on the repo in order to make a release.