### PR TITLE
Publishing: Do not fetch resources before publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,8 @@ jobs:
       - name: Install
         run: npm ci
 
-      - name: Bundle
-        run: npm run prerelease
-
       - name: Lint
         run: npm run lint
-
-      - name: Clean
-        run: git reset --hard
 
       - name: Create release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Clean
+        run: git reset --hard
+
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-gbe": "CLIQZ_OUTPUT_PATH=./build/gbe ./fern.js build configs/ghostery.js",
     "build-ios": "CLIQZ_OUTPUT_PATH=./build/ios ./fern.js build configs/user-agent-ios.js",
     "fetch-resources": "node modules/antitracking/fetch-resources.js",
-    "prerelease": "npm run fetch-resources && npm run build-gbe && npm run build-ios",
+    "prerelease": "npm run build-gbe && npm run build-ios",
     "release": "auto shipit"
   },
   "repository": {


### PR DESCRIPTION
Removes automatic fetching of latest anti-tracking resources before publish, as this requires a dirty working copy, which auto will refuse to publish.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.2-canary.10.313bf1b.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install ghostery-common@1.0.2-canary.10.313bf1b.0
  # or 
  yarn add ghostery-common@1.0.2-canary.10.313bf1b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
