### PR TITLE
Update adblocker to v1.20 to bring initial procedural filters support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cliqz/ghostery-common",
+  "name": "ghostery-common",
   "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -1329,22 +1329,24 @@
       }
     },
     "@cliqz/adblocker": {
-      "version": "1.18.8",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-1.18.8.tgz",
-      "integrity": "sha512-19m0GhlOcdSvQ/BqVuaMgbYkgQ4ys8koBRW4K7Ua4V5fFWL0t8ckdcZ/gBOqwECS2m8agXSpEbbyJjNmHBHpMQ==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-1.20.0.tgz",
+      "integrity": "sha512-lkEj0Pj1ikwMURrvoFv0YnLfaXFuJI+jexI7zdh4fDmlwRppzDDgOhPXgCczoAlYacJk5x2mf7pan6JybRD9Kw==",
       "requires": {
+        "@cliqz/adblocker-content": "^1.20.0",
+        "@cliqz/adblocker-extended-selectors": "^1.20.0",
         "@remusao/guess-url-type": "^1.1.2",
         "@remusao/small": "^1.1.2",
         "@remusao/smaz": "^1.7.1",
-        "@types/chrome": "^0.0.126",
+        "@types/chrome": "^0.0.128",
         "@types/firefox-webext-browser": "^82.0.0",
         "tldts-experimental": "^5.6.21"
       },
       "dependencies": {
         "@types/chrome": {
-          "version": "0.0.126",
-          "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.126.tgz",
-          "integrity": "sha512-191z7uoyfbGU+z7/m45j9XbWugWqVHVPMM4hJV5cZ+3YzGCT9wFjMUHO3Wr3Xvo8aVodvRNu28u7lvEaAnfbzg==",
+          "version": "0.0.128",
+          "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.128.tgz",
+          "integrity": "sha512-eGc599TDtersMBW1cSnExHm0IHrXrO5xdk6Sa2Dq30ED+hR1rpT1ez0NNcCgvGO52nmktGfyvd3Uyquzv3LL4g==",
           "requires": {
             "@types/filesystem": "*",
             "@types/har-format": "*"
@@ -1353,27 +1355,36 @@
       }
     },
     "@cliqz/adblocker-content": {
-      "version": "1.18.8",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-content/-/adblocker-content-1.18.8.tgz",
-      "integrity": "sha512-YZ1xYBVG3LmxsdTYvTs/Bc7pzCw/Dy4HFo6N+oIuGP+Le/0aGSkACUl3ue5I2+Cx0WmL0Z8I4QonTKDc06HR+A=="
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-content/-/adblocker-content-1.20.0.tgz",
+      "integrity": "sha512-KcokmK2B+tAnVMi7nGHgzXUVf78wAODG1Uk+K3tBPf9VAo3mwldYZ472uTj6LUfZv5oeTwe4PwfmPWXWZy3Eew==",
+      "requires": {
+        "@cliqz/adblocker-extended-selectors": "^1.20.0"
+      }
+    },
+    "@cliqz/adblocker-extended-selectors": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-extended-selectors/-/adblocker-extended-selectors-1.20.0.tgz",
+      "integrity": "sha512-dnBPIngGe1eDWvYX49eP2yyCE2AY1QD5E+8SaXW6lslnjS0GQnkcXCAkkGR2am4Qdk78HAiWTXL65Zt9hdkupA=="
     },
     "@cliqz/adblocker-webextension": {
-      "version": "1.18.8",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-webextension/-/adblocker-webextension-1.18.8.tgz",
-      "integrity": "sha512-ZdgIEmETSOmg5TEs54KqwsALCB2kQpYN+Tqhelr0T5G2N+YHvZHc8t5V+uit829jEGHKPhHjSBhDkfDcjHK3Jw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-webextension/-/adblocker-webextension-1.20.0.tgz",
+      "integrity": "sha512-AuIa04SzCZUTphVtZx75tsbejO9k5kiI71rzzTdELt7peW2aNatyXTtzIe2f62HqMKgiMKCTZZiPi6Fak7Jvkg==",
       "requires": {
-        "@cliqz/adblocker": "^1.18.8",
-        "@cliqz/adblocker-content": "^1.18.8",
+        "@cliqz/adblocker": "^1.20.0",
+        "@cliqz/adblocker-content": "^1.20.0",
         "tldts-experimental": "^5.6.21",
         "webextension-polyfill-ts": "^0.22.0"
       }
     },
     "@cliqz/adblocker-webextension-cosmetics": {
-      "version": "1.18.8",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-webextension-cosmetics/-/adblocker-webextension-cosmetics-1.18.8.tgz",
-      "integrity": "sha512-epQLl7POmuH5l1WYXEzR6TYZktgxxJ+UVXEAkN1CX98PJfdEGtbzL7C2gaBdstLSuAIdCZQ9Xrw4BLF2MoFlmw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-webextension-cosmetics/-/adblocker-webextension-cosmetics-1.20.0.tgz",
+      "integrity": "sha512-AkfuXHzMw/L9rq9iLzw5bzjU7EgBDpWL6eR/VB9gqrPeprj8NR8jDH74DFIzW6KZ4CGM77q1WEz3LUEG3d3nfA==",
       "requires": {
-        "@cliqz/adblocker-content": "^1.18.8"
+        "@cliqz/adblocker-content": "^1.20.0",
+        "@cliqz/adblocker-extended-selectors": "^1.20.0"
       }
     },
     "@cliqz/metalint": {
@@ -10217,10 +10228,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "dev": true,
-      "requires": {
-        "icu4c-data": "^0.64.2"
-      }
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -11198,12 +11206,6 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
-    },
-    "icu4c-data": {
-      "version": "0.64.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
-      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ==",
-      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",
@@ -13957,8 +13959,7 @@
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-forge": {
       "version": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -135,8 +135,8 @@
   },
   "dependencies": {
     "@cliqz-oss/dexie": "^2.0.4",
-    "@cliqz/adblocker-webextension": "^1.18.8",
-    "@cliqz/adblocker-webextension-cosmetics": "^1.18.8",
+    "@cliqz/adblocker-webextension": "^1.20.0",
+    "@cliqz/adblocker-webextension-cosmetics": "^1.20.0",
     "@cliqz/url-parser": "^1.1.4",
     "abortcontroller-polyfill": "^1.5.0",
     "anonymous-credentials": "https://github.com/cliqz-oss/anonymous-credentials/releases/download/1.0.0/anonymous-credentials-1.0.0.tgz",


### PR DESCRIPTION
# What Changed

- [x] Add support for `:remove()` modifier (`:style` updated to support procedural filters).
- [x] Remove stylesheet injection from content script.
- [x] Replace Closure compiler with Terser.
- [x] Handle procedural filters:
  - [x] `:has` and `:if`
  - [x] `:has-text`
  - [x] `:not`
- [x] Support procedural filters on WebExtension.
- [x] Improve test coverage.

## Release Notes

Add initial support for extended CSS selectors (a.k.a. procedural filters) as well as the `:remove()` modifier for element hiding rules (note: the already supported `:style` modified now also works with extended CSS selectors). The following new pseudo-classes are implemented: `:has` (and its alias `:if`), `:has-text` (both string and RegExp literals), and `:not` (whenever its argument is also an extended selector, otherwise fallback to native implementation).

Caveats:
* Loading of extended css filters is disabled by default and needs to be toggled using the `loadExtendedSelectors` option while [initializing the blocker instance](https://github.com/cliqz-oss/adblocker/blob/3361723138f40c3cb96b4c6e611f2b030f75d891/packages/adblocker-webextension-example/background.ts#L61).
* These news selectors are currently only supported by `WebExtensionBlocker` (support for Puppeteer, Electron and Playwright is not planned at this time but help from the community would be greatly appreciated).

Miscellaneous changes:
* Removal of unused `injectCSSRule` helper.
* Replace Closure compiler by Terser.