### PR TITLE
Improve monitoring ("alive" signal in HW & Edge browser detection in Antitracking) 

### DIFF
--- a/modules/antitracking/sources/background.es
+++ b/modules/antitracking/sources/background.es
@@ -20,7 +20,7 @@ import Config, { TELEMETRY } from './config';
 import { updateTimestamp } from './time';
 import { bindObjectFunctions } from '../core/helpers/bind-functions';
 import inject from '../core/kord/inject';
-import { isEdge } from '../core/platform';
+import { isLegacyEdge } from '../core/platform';
 import { parse } from '../core/url';
 
 // Telemetry schemas
@@ -74,7 +74,7 @@ export default background({
 
     // load config
     this.config = new Config({}, () => this.core.action('refreshAppState'));
-    if (isEdge) {
+    if (isLegacyEdge) {
       this.config.databaseEnabled = false;
     }
     this.attrack.webRequestPipeline.action('getPageStore').then((pageStore) => {

--- a/modules/antitracking/sources/telemetry.es
+++ b/modules/antitracking/sources/telemetry.es
@@ -27,10 +27,12 @@ function getPlatformConstants() {
     let userAgent = '';
     if (pltfrm.isFirefox) {
       userAgent = 'firefox';
-    } else if (pltfrm.isChromium) {
-      userAgent = 'chrome';
     } else if (pltfrm.isEdge) {
       userAgent = 'edge';
+    } else if (pltfrm.isLegacyEdge) {
+      userAgent = 'legacy-edge';
+    } else if (pltfrm.isChromium) {
+      userAgent = 'chrome';
     }
     return {
       platform: pltfrm.isMobile ? 'mobile' : '',

--- a/modules/core/sources/platform.es
+++ b/modules/core/sources/platform.es
@@ -26,6 +26,7 @@ export const isFirefox = platform.isFirefox;
 export const isMobile = platform.isMobile || Boolean(config.isMobile);
 export const isChromium = platform.isChromium;
 export const isEdge = platform.isEdge;
+export const isLegacyEdge = platform.isLegacyEdge;
 export const platformName = platform.platformName;
 export const isCliqzBrowser = channel === '40' || channel === '99';
 export const isGhosteryExtension = channel.startsWith('CH');

--- a/modules/core/sources/webrequest.es
+++ b/modules/core/sources/webrequest.es
@@ -7,7 +7,7 @@
  */
 
 import webrequest, { VALID_RESPONSE_PROPERTIES } from '../platform/webrequest';
-import { isEdge } from './platform';
+import { isLegacyEdge } from './platform';
 
 export default webrequest;
 
@@ -34,7 +34,7 @@ function getOptionArray(options) {
 }
 
 // build allowed extraInfo options from <Step>Options objects.
-export const EXTRA_INFO_SPEC = !isEdge ? {
+export const EXTRA_INFO_SPEC = !isLegacyEdge ? {
   onBeforeRequest: getOptionArray(webrequest.OnBeforeRequestOptions),
   onBeforeSendHeaders: getOptionArray(webrequest.OnBeforeSendHeadersOptions),
   onSendHeaders: getOptionArray(webrequest.OnSendHeadersOptions),

--- a/modules/human-web/sources/alive-message-generator.es
+++ b/modules/human-web/sources/alive-message-generator.es
@@ -1,0 +1,106 @@
+/*!
+ * Copyright (c) 2014-present Cliqz GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import UAParser from 'ua-parser-js';
+import logger from './logger';
+
+/**
+ * Responsible for generating information to be included in the "alive" message.
+ * The purpose of the additional information in the alive message is to detect
+ * unusual traffic, for instance, if a new browser version introduced a regression.
+ *
+ * The information will only be included if it has been seen by multiple users.
+ * The data itself should not be sensitive, still there is no point in including it
+ * as only "big hitters" are interesting. For instance, should there be a problem in
+ * an obscure setup, it is less interesting then if a recent Firefox or Chrome release
+ * breaks something on Windows.
+ */
+export default class AliveMessageGenerator {
+  constructor(quorumChecker, aliveConfigStorage) {
+    this.quorumChecker = quorumChecker;
+    this.aliveConfigStorage = aliveConfigStorage;
+  }
+
+  async generateMessage(countryCode, hour) {
+    const parser = UAParser();
+    parser.browser = parser.browser || {};
+    parser.os = parser.os || {};
+
+    const browser = parser.browser.name || '';
+    const os = parser.os.name || '';
+
+    // extracts only the major version (e.g. "96.0.1" -> 96)
+    let version = parseInt(parser.browser.version, 10);
+    if (isNaN(version)) {
+      version = '';
+    }
+
+    const config = {
+      browser,
+      version, // major version
+      os,
+      ctry: countryCode, // sanitized country ('--' for countries with a small population)
+    };
+    try {
+      const reachedQuorum = await this._reachedQuorum(config);
+      if (reachedQuorum) {
+        config.t = hour;
+        logger.debug('Found the following configuration safe to share:', config);
+        return config;
+      }
+    } catch (e) {
+      logger.warn('Failed to confirm that the configuration is popular enough:', e);
+    }
+
+    logger.debug('Omitting the config, as it is not popular enough:', config);
+    return {
+      browser: '',
+      version: '',
+      os: '',
+      ctry: '--',
+      t: hour,
+    };
+  }
+
+  /**
+   * Checks that the additional configuration is popular enough to be shared.
+   * As long as the configuration does not change, keep the initial result of the
+   * quorum check. Otherwise, it might happen that it reaches quorum over time
+   * by itself (provided that we keep sharing it and it never changes).
+   *
+   * If there is a false positive (a popular config being not detected), it will
+   * eventually recover as the configuration will changed over time (e.g. after each
+   * browser update).
+   */
+  async _reachedQuorum(config) {
+    const newConfig = this._deterministicStringify(config);
+    let reachedQuorum = null;
+
+    try {
+      const oldValue = await this.aliveConfigStorage.load();
+      if (oldValue && newConfig === oldValue.config) {
+        reachedQuorum = oldValue.reachedQuorum;
+      }
+    } catch (e) {
+      logger.warn('Ignore errors when reading the old state, but check the quorum again', e);
+    }
+
+    if (reachedQuorum === null) {
+      reachedQuorum = await this.quorumChecker(newConfig);
+      await this.aliveConfigStorage.store({
+        config: newConfig,
+        reachedQuorum,
+      });
+    }
+    return reachedQuorum;
+  }
+
+  _deterministicStringify(config) {
+    return JSON.stringify(Object.keys(config).sort().map(x => config[x]));
+  }
+}

--- a/modules/human-web/sources/human-web-patterns-loader.ts
+++ b/modules/human-web/sources/human-web-patterns-loader.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { isEdge } from '../core/platform';
+import { isLegacyEdge } from '../core/platform';
 import {
   RemoteResourceWatcher,
   ResourceUpdatedCallback
@@ -36,7 +36,7 @@ ZpJDPOb9RzbPMOawfjPhkayRb9yvU0f6pLvKm6kmKLsoblsaeLFbhu1igO8nXP4X
 -----END PUBLIC KEY-----`,
   },
 
-  // fallback for Edge
+  // fallback for legacy Edge (before Chrome)
   '2019-10-24-human-web-edge.pub': {
     algorithm: 'RSASSA-PKCS1-v1_5',
     pem: `-----BEGIN PUBLIC KEY-----
@@ -74,7 +74,7 @@ export default class SignedPatternsLoader {
 
   constructor(url: string, onUpdate: ResourceUpdatedCallback) {
     const publicKeyName =
-      isEdge ? '2019-10-24-human-web-edge.pub' : '2019-10-24-human-web.pub';
+      isLegacyEdge ? '2019-10-24-human-web-edge.pub' : '2019-10-24-human-web.pub';
     const { algorithm, pem } = trustedSigningKeys[publicKeyName];
 
     this.verifier = new SignatureVerifier({

--- a/modules/human-web/tests/integration/human-web-test.es
+++ b/modules/human-web/tests/integration/human-web-test.es
@@ -88,13 +88,13 @@ export default function () {
 
       notAllowed.forEach((e) => {
         it(`'${e}'is not allowed`, function () {
-          expect(CliqzHumanWeb.sanitizeCounrtyCode(e)).to.equal('--');
+          expect(CliqzHumanWeb.sanitizeCountryCode(e)).to.equal('--');
         });
       });
 
       allowed.forEach((e) => {
         it(`'${e}' is allowed`, function () {
-          expect(CliqzHumanWeb.sanitizeCounrtyCode(e)).to.equal(e);
+          expect(CliqzHumanWeb.sanitizeCountryCode(e)).to.equal(e);
         });
       });
     });

--- a/platforms/node/platform.es
+++ b/platforms/node/platform.es
@@ -11,6 +11,7 @@ export default {
   isFirefox: false,
   isChromium: false,
   isEdge: false,
+  isLegacyEdge: false,
   platformName: 'node',
 };
 

--- a/platforms/react-native/platform.es
+++ b/platforms/react-native/platform.es
@@ -13,6 +13,7 @@ export default {
   isFirefox: false,
   isChromium: false,
   isEdge: false,
+  isLegacyEdge: false,
   platformName: 'mobile',
 };
 

--- a/platforms/webextension/human-web/storage.es
+++ b/platforms/webextension/human-web/storage.es
@@ -68,6 +68,8 @@ const humanWebChromeDB = {
   },
 };
 
+const ALIVE_CONFIG_KEY = 'hw:alive-config';
+
 export default class {
   constructor(CliqzHumanWeb) {
     this.CliqzHumanWeb = CliqzHumanWeb;
@@ -207,6 +209,33 @@ export default class {
     this.dbConn.remove('usafe', url, () => {
       // Need to find better error handling for chrome storage.
       callback(true);
+    });
+  }
+
+  loadAliveConfig() {
+    return new Promise((resolve, reject) => {
+      chrome.storage.local.get(ALIVE_CONFIG_KEY, (value) => {
+        if (chrome.runtime.lastError) {
+          reject(chrome.runtime.lastError);
+          return;
+        }
+        resolve(value[ALIVE_CONFIG_KEY]);
+      });
+    });
+  }
+
+  storeAliveConfig(config) {
+    return new Promise((resolve, reject) => {
+      const entry = {
+        [ALIVE_CONFIG_KEY]: config,
+      };
+      chrome.storage.local.set(entry, () => {
+        if (chrome.runtime.lastError) {
+          reject(chrome.runtime.lastError);
+          return;
+        }
+        resolve();
+      });
     });
   }
 }

--- a/platforms/webextension/platform.es
+++ b/platforms/webextension/platform.es
@@ -16,11 +16,19 @@ function checkUserAgent(pattern) {
   }
 }
 
+// Note: Chrome-forks such as Edge or Opera will also be reported
+// as Chromium ("isChromium" will be true). Technically, there should
+// be no difference, so most parts in the code will only test for
+// isFirefox vs isChromium vs isMobile .
+//
+// If you need the fine grained resolution, start with testing the
+// more specific ones (e.g. isEdge) before the generic "isChromium".
 const def = {
   isMobile: checkUserAgent('Mobile'),
   isFirefox: checkUserAgent('Firefox'),
   isChromium: checkUserAgent('Chrome'),
-  isEdge: checkUserAgent('Edge'),
+  isEdge: checkUserAgent('Edg') && !checkUserAgent('Edge'), // chromium-based edge
+  isLegacyEdge: checkUserAgent('Edge'),
   platformName: 'webextension',
 };
 


### PR DESCRIPTION
Fixed: Edge should not be reported as Chrome by Antitracking.

Also, include the browser (name + major version) and OS in the "alive" action. Skip it for more uncommon combinations (i.e. unable of reaching quorum). If it reaches quorum, it can look like that:

```
{
  "type": "humanweb",
  "action": "alive",
  "payload": {
    "browser": "Chrome",
    "version": 98,
    "os": "Linux",
    "ctry": "de",
    "t": "2022012423"
  },
  "ver": "2.7",
  "channel": "ghostery",
  "ts": "20220125",
  "anti-duplicates": 2604168
}
```

Otherwise, the extra value will be omitted:

```
{
  "type": "humanweb",
  "action": "alive",
  "payload": {
    "browser": "",
    "version": "",
    "os": "",
    "ctry": "--",
    "t": "2022012423"
  },
  "ver": "2.7",
  "channel": "ghostery",
  "ts": "20220125",
  "anti-duplicates": 2604168
}
```