### PR TITLE
Do not require the history API to be present

### DIFF
--- a/modules/search/sources/performance-telemetry.es
+++ b/modules/search/sources/performance-telemetry.es
@@ -15,11 +15,15 @@ export default {
     this.onVisited = () => {
       telemetry.push({ visitsCount: 1 }, 'metrics.history.visits.count');
     };
-    chrome.history.onVisited.addListener(this.onVisited);
+    if (chrome.history && chrome.history.onVisited) {
+      chrome.history.onVisited.addListener(this.onVisited);
+    }
   },
 
   unload() {
-    chrome.history.onVisited.removeListener(this.onVisited);
+    if (chrome.history && chrome.history.removeListener) {
+      chrome.history.onVisited.removeListener(this.onVisited);
+    }
   },
 
   events: {


### PR DESCRIPTION
chrome.history.onVisited is not present when running integration tests.