### PR TITLE
Return `false` from the handler, as it doesn't use sendResponse argument

### DIFF
--- a/platforms/webextension/content-communication-manager.es
+++ b/platforms/webextension/content-communication-manager.es
@@ -36,7 +36,9 @@ function handleRequest(message, sender) {
     return undefined;
   }
 
-  return inject.module(module).action(action, ...args, sender);
+  inject.module(module).action(action, ...args, sender);
+
+  return false;
 }
 
 export default class ContentCommunicationManager {


### PR DESCRIPTION
Fixes https://github.com/ghostery/ghostery-extension/issues/806.

We are not using the `sendResponse` third argument in the `handleRequest` function, so we should always return `false`. For now, it returns a promise, so the API holds for using the `sendResponse`, which never happens. As the result, the error message is thrown in the console.