### PR TITLE
Add support for the new "push injections" in the adblocker library

### DIFF
--- a/modules/adblocker/sources/adblocker.es
+++ b/modules/adblocker/sources/adblocker.es
@@ -178,7 +178,13 @@ export default class Adblocker {
       return skip('adblocker engine is not ready');
     }
     if (details.url === 'about:blank') {
-      // TODO: Should we skip it?
+      // Unless there is evidence that we have to drop it, it is best to
+      // rely on the adblocker engine how to deal with it. Dropping the
+      // event only for optimization purposes is not necessary, since
+      // the adblocker engine will not spend much time processing it.
+      //
+      // Note that continuing with the other checks does not make sense,
+      // since they all assume it is a normal URL.
       return true;
     }
 

--- a/modules/adblocker/sources/adblocker.es
+++ b/modules/adblocker/sources/adblocker.es
@@ -73,8 +73,12 @@ export default class Adblocker {
     for (const site of config.trustedSitesSnapshot) {
       this.trustedSites.add(site);
 
-      // Drop the leading "www." to be closer to the code in the extension here:
+      // The source of truth for the "trusted site" logic is here:
       // https://github.com/ghostery/ghostery-extension/blob/5aea0820fc4f590b21d04611ec71a6b7bcf85202/extension-manifest-v2/src/classes/Policy.js#L62
+      //
+      // It includes a normalization step that ignores leading "www."
+      // in the hostname. To keep it a simple lookup, we can duplicate
+      // the entries (once with and once without the leading "www.").
       if (!site.startsWith('www.')) {
         this.trustedSites.add(`www.${site}`);
       }

--- a/modules/adblocker/sources/background.es
+++ b/modules/adblocker/sources/background.es
@@ -243,14 +243,11 @@ export default background({
         return { active: false };
       }
 
-      return new Promise((resolve) => {
-        this.adblocker.manager.engine.handleRuntimeMessage(
-          browser,
-          { action: 'getCosmeticsFilters', ...payload },
-          sender,
-          resolve,
-        ).catch(() => { /* it's ok if this fails */ });
-      });
+      return this.adblocker.manager.engine.onRuntimeMessage(
+        browser,
+        { action: 'getCosmeticsFilters', ...payload },
+        sender
+      );
     },
 
     /**

--- a/modules/adblocker/sources/background.es
+++ b/modules/adblocker/sources/background.es
@@ -19,6 +19,7 @@ import config, {
   ADB_PREF_STRICT,
   ADB_USER_LANG,
   ADB_MODE,
+  ADB_TRUSTED_SITES,
 } from './config';
 import { isUrl, parse } from '../core/url';
 import telemetry from '../core/services/telemetry';
@@ -213,6 +214,10 @@ export default background({
         } else if (this.adblocker !== null && config.enabled === false) {
           logger.log('Adblocker pref switched: unload');
           this.shallowUnload();
+        }
+      } else if (pref === ADB_TRUSTED_SITES) {
+        if (this.adblocker) {
+          this.adblocker.syncTrustedSites();
         }
       }
     },

--- a/modules/adblocker/sources/config.es
+++ b/modules/adblocker/sources/config.es
@@ -32,6 +32,7 @@ export const ADB_PREF_STRICT = 'cliqz-adb-strict';
 export const ADB_USER_LANG = 'cliqz-adb-lang';
 export const ADB_MODE = 'cliqz_adb_mode';
 export const ADB_FETCH = 'cliqz-adb-fetch-enabled';
+export const ADB_TRUSTED_SITES = 'adb-trusted-sites';
 
 const ADS_ONLY = 'ads';
 const ADS_AND_TRACKERS = 'ads-trackers';
@@ -134,6 +135,13 @@ class Config {
 
   set networkFetchEnabled(value) {
     prefs.set(ADB_FETCH, value);
+  }
+
+  /**
+   * Readonly value.
+   */
+  get trustedSitesSnapshot() {
+    return prefs.get(ADB_TRUSTED_SITES, []);
   }
 }
 

--- a/modules/adblocker/sources/config.es
+++ b/modules/adblocker/sources/config.es
@@ -9,7 +9,22 @@
 import console from '../core/console';
 import prefs from '../core/prefs';
 import cliqzConfig from '../core/config';
-import { isMobile } from '../core/platform';
+import { isMobile, isFirefox } from '../core/platform';
+
+// This flag controls how scriptlets should be injected. It has
+// to match the defaults in the adblocker libary.
+//
+// Note that the adblocker libray will automatically decide how to
+// inject scriptlets. If possible, this should stay an implementation
+// detail; but since we are wrapping the adblocker library, this
+// abstraction unfortunately leaks, for these reasons:
+// * The wrapper is responsible for triggering the onCommitted events
+// * The wrapper has to prevent injecting scriptlets twice
+//
+// The source of truth is how the adblocker library handles it
+// (search for "enablePushInjectionsOnNavigationEvents" in
+// https://github.com/ghostery/adblocker).
+export const USE_PUSH_INJECTIONS_ON_NAVIGATION_EVENTS = !isFirefox;
 
 // Preferences
 export const ADB_PREF = 'cliqz-adb';

--- a/modules/adblocker/sources/content.es
+++ b/modules/adblocker/sources/content.es
@@ -8,7 +8,6 @@
 
 import injectCosmetics from '../platform/lib/adblocker-cosmetics';
 import { registerContentScript } from '../core/content/register';
-import { USE_PUSH_INJECTIONS_ON_NAVIGATION_EVENTS } from './config';
 
 registerContentScript({
   module: 'adblocker',
@@ -30,11 +29,6 @@ registerContentScript({
       true, /* enable mutation observer */
       async (payload) => {
         const result = await CLIQZ.app.modules.adblocker.action('getCosmeticsFilters', payload);
-        if (USE_PUSH_INJECTIONS_ON_NAVIGATION_EVENTS && result) {
-          // prevent double-injection of scripts (the adblocker is
-          // configured to inject them via tabs.executeScript)
-          result.scripts = [];
-        }
         return result || {};
       },
     );

--- a/modules/adblocker/sources/content.es
+++ b/modules/adblocker/sources/content.es
@@ -8,6 +8,7 @@
 
 import injectCosmetics from '../platform/lib/adblocker-cosmetics';
 import { registerContentScript } from '../core/content/register';
+import { USE_PUSH_INJECTIONS_ON_NAVIGATION_EVENTS } from './config';
 
 registerContentScript({
   module: 'adblocker',
@@ -29,6 +30,11 @@ registerContentScript({
       true, /* enable mutation observer */
       async (payload) => {
         const result = await CLIQZ.app.modules.adblocker.action('getCosmeticsFilters', payload);
+        if (USE_PUSH_INJECTIONS_ON_NAVIGATION_EVENTS && result) {
+          // prevent double-injection of scripts (the adblocker is
+          // configured to inject them via tabs.executeScript)
+          result.scripts = [];
+        }
         return result || {};
       },
     );

--- a/modules/core/sources/url-whitelist.es
+++ b/modules/core/sources/url-whitelist.es
@@ -144,7 +144,7 @@ export default class UrlWhitelist {
         }
         break;
       default:
-        this.logger.error('Supprted actions: add, remove, toggle', action);
+        this.logger.error('Supported actions: add, remove, toggle', action);
         return;
     }
     if (!deferPersist) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@cliqz-oss/dexie": "^2.0.4",
-        "@cliqz/adblocker-webextension": "^1.24.0",
-        "@cliqz/adblocker-webextension-cosmetics": "^1.24.0",
+        "@cliqz/adblocker-webextension": "^1.25.0",
+        "@cliqz/adblocker-webextension-cosmetics": "^1.25.0",
         "@cliqz/url-parser": "^1.1.4",
         "abortcontroller-polyfill": "^1.5.0",
         "anonymous-credentials": "https://github.com/whotracksme/anonymous-credentials/releases/download/1.0.0/anonymous-credentials-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -135,8 +135,8 @@
   },
   "dependencies": {
     "@cliqz-oss/dexie": "^2.0.4",
-    "@cliqz/adblocker-webextension": "^1.24.0",
-    "@cliqz/adblocker-webextension-cosmetics": "^1.24.0",
+    "@cliqz/adblocker-webextension": "^1.25.0",
+    "@cliqz/adblocker-webextension-cosmetics": "^1.25.0",
     "@cliqz/url-parser": "^1.1.4",
     "abortcontroller-polyfill": "^1.5.0",
     "anonymous-credentials": "https://github.com/whotracksme/anonymous-credentials/releases/download/1.0.0/anonymous-credentials-1.0.0.tgz",


### PR DESCRIPTION
This is how the changes from https://github.com/ghostery/adblocker/pull/2750 can be tested in Ghostery.

Depends also on https://github.com/ghostery/ghostery-extension/pull/839 (i.e. both have to updated at the same time)
