### PR TITLE
Use "pagehide" instead of "unload"

### DIFF
--- a/modules/core/sources/content.es
+++ b/modules/core/sources/content.es
@@ -171,7 +171,7 @@ registerContentScript({
       window.addEventListener('DOMContentLoaded', onDOMContentLoaded);
 
       // Stop listening
-      window.addEventListener('unload', () => {
+      window.addEventListener('pagehide', () => {
         window.removeEventListener('mousedown', onMouseDown);
         window.removeEventListener('DOMContentLoaded', onDOMContentLoaded);
       }, { once: true });

--- a/modules/core/sources/content/run.es
+++ b/modules/core/sources/content/run.es
@@ -100,7 +100,7 @@ export default function () {
     contentScriptActions.setActionCallbacks(runContentScripts(window, chrome, CLIQZ));
 
     // Stop listening for messages on window unload
-    window.addEventListener('unload', () => {
+    window.addEventListener('pagehide', () => {
       contentScriptActions.unload();
     }, { once: true });
   });

--- a/modules/human-web/sources/content.es
+++ b/modules/human-web/sources/content.es
@@ -203,7 +203,7 @@ function contentScript(window, chrome, CLIQZ) {
     window.removeEventListener('copy', onCopy);
   }
 
-  window.addEventListener('unload', stop);
+  window.addEventListener('pagehide', stop);
 }
 
 registerContentScript({

--- a/modules/webextension-specific/sources/app.bundle.es
+++ b/modules/webextension-specific/sources/app.bundle.es
@@ -58,7 +58,7 @@ CLIQZ.app
     triggerOnboardingOffers(false);
   });
 
-window.addEventListener('unload', () => {
+window.addEventListener('pagehide', () => {
   CLIQZ.app.stop();
   chrome.runtime.onInstalled.removeListener(onboarding);
 });

--- a/modules/webrequest-pipeline/tests/integration/webrequest-pipeline-test.es
+++ b/modules/webrequest-pipeline/tests/integration/webrequest-pipeline-test.es
@@ -260,7 +260,7 @@ export default () => {
           testServer.registerPathHandler(getSuffix(), {
             result: `<html><body><script>
               navigator.sendBeacon('${getSuffix('beacon')}', 'foo');
-              window.addEventListener('unload', () => {
+              window.addEventListener('pagehide', () => {
                 var client = new XMLHttpRequest();
                 client.open('GET', '${getSuffix('beacon')}', false);
                 client.send(null);
@@ -336,7 +336,7 @@ export default () => {
         testServer.registerPathHandler(getSuffix('frame'), {
           result: `<html><body><script>
             navigator.sendBeacon('${getSuffix('beacon')}', 'foo');
-            window.addEventListener('unload', () => {
+            window.addEventListener('pagehide', () => {
               navigator.sendBeacon('${getSuffix('beacon')}', 'bar');
               var client = new XMLHttpRequest();
               client.open('GET', '${getSuffix('beacon')}', ${isChromium ? 'true' : 'false'});


### PR DESCRIPTION
Follows the recommendation to use "pagehide" instead of "unload":
https://web.dev/bfcache/#never-use-the-unload-event

refs https://github.com/ghostery/ghostery-extension/issues/836