### PR TITLE
keep "unload" events in the context of background scripts

### DIFF
--- a/modules/webextension-specific/sources/app.bundle.es
+++ b/modules/webextension-specific/sources/app.bundle.es
@@ -58,7 +58,7 @@ CLIQZ.app
     triggerOnboardingOffers(false);
   });
 
-window.addEventListener('pagehide', () => {
+window.addEventListener('unload', () => {
   CLIQZ.app.stop();
   chrome.runtime.onInstalled.removeListener(onboarding);
 });


### PR DESCRIPTION
Reverting: "unload" is here used in the context of the background page, while the change from o "pagehide" should be done only for content scripts.

(Note: "webextension-specific" modules is not used in Ghostery; still changing "unload" to "pagehide" in this context is not sound)

refs https://github.com/ghostery/common/pull/53