### PR TITLE
Configure the fields for client-side message deduplication in the patterns

### DIFF
--- a/modules/human-web-lite/sources/duplicate-detector.es
+++ b/modules/human-web-lite/sources/duplicate-detector.es
@@ -15,9 +15,127 @@ const MINUTE = 60 * SECOND;
 const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
 
-const KEY_COMPUTATION = {
-  'hwlite.query': msg => truncatedHash(`query:${msg.ts}:${msg.payload.q}`),
-};
+/**
+ * Takes an object and returns a sorted representation. Specially,
+ * it ensures that the ordering of object keys does not matter.
+ *
+ * { foo: 42, bar: 'baz' } <=> { bar: 'baz', foo: 42 }
+ */
+function objectToOrderedArray(x) {
+  if (x === null || x === undefined) {
+    // both are missing values in our context and therefore equal
+    return null;
+  }
+  if (typeof x === 'string' || typeof x === 'number' || typeof x === 'boolean') {
+    return x;
+  }
+  if (Array.isArray(x)) {
+    return x.map(objectToOrderedArray);
+  }
+  if (typeof x === 'object') {
+    // With this simple implementation, these two objects will be mapped to
+    // the same representation: { foo: 42 } and [["foo", 42]]
+    //
+    // For our purpose that is OK:
+    // 1) the collision detection will accept false-positive, since later
+    //    the value will be hashed (to introduce collisions!)
+    // 2) the structure of objects with the same action should be the same;
+    //    in other words, the example here should not happen
+    return Object.keys(x).sort().map(key => [key, objectToOrderedArray(x[key])]);
+  }
+  throw new Error('Internal error: input contains unexpected types');
+}
+
+function extractPath(obj, path, pos = 0) {
+  const nextKey = path[pos];
+  if (nextKey === '[]') {
+    if (Array.isArray(obj)) {
+      const results = obj.map(x => extractPath(x, path, pos + 1)).filter(x => x.match);
+      if (results.length > 0) {
+        return { match: true, value: results };
+      }
+    }
+    return { match: false };
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(obj, nextKey)) {
+    return { match: false };
+  }
+
+  const elem = obj[nextKey];
+  if (pos === path.length - 1) {
+    return { match: true, value: elem };
+  }
+  return extractPath(elem, path, pos + 1);
+}
+
+/**
+ * Two messages are considered duplicates iff the following tuple is the same:
+ * 1) action
+ * 2) timestamp ("ts" field)
+ * 3) key fields in payload
+ *
+ * By default, all fields in the payload are considered, but this can be
+ * overwritten by the "deduplicateBy" parameter. It is a comma-separated
+ * list of dot-separated paths.
+ *
+ * For instance, "k" would only extract the field named "k", so the following
+ * two messages would be considered duplicates:
+ *
+ * msg1 = {
+ *   "k": "key text",
+ *   "x": "some text not part of the key"
+ * }
+ *
+ * msg2 = {
+ *   "k": "key text",
+ *   "x": "another text not part of the key"
+ * }
+ *
+ * Both messages would not be duplicates in the default (considering the
+ * full payload), or it both keys were listed ("k,x").
+ *
+ * The path allows to extract inner fields:
+ *
+ * msg = {
+ *   "a": 42,
+ *   "b": {
+ *     "c: "inner",
+ *   },
+ *   "d": "not extracted"
+ * }
+ *
+ * 'a,b.c' will extract the values 42 and "inner", but not the value for field "d".
+ *
+ * Arrays can be either aggregated with [] or accessed by an index:
+ *
+ * msg = {
+ *   a: [1,2,3],
+ *   b: [{
+ *     c: 4,
+ *     d: "ignore"
+ *   }, {
+ *     c: 5,
+ *     d: "ignore",
+ *   }]
+ * }
+ *
+ * by []:    'a,b.[].c' will extract the values [1,2,3], 4 and 5.
+ * by index: 'a,b.0.c' will extract the values [1,2,3] and 4.
+ * by index: 'a,b.1.c' will extract the values [1,2,3] and 5.
+ */
+export function computeDeduplicationKey({ body, deduplicateBy = '' }) {
+  let keys = body.payload;
+  if (!deduplicateBy) {
+    keys = body.payload;
+  } else {
+    keys = deduplicateBy.split(',').map(path =>
+      extractPath(body.payload, path.split('.'), 0).value);
+  }
+
+  const { action, ts } = body;
+  return JSON.stringify([action, ts, objectToOrderedArray(keys)]);
+}
 
 /**
  * Well-behaving clients should not send the same message multiple times.
@@ -59,7 +177,7 @@ export default class DuplicateDetector {
 
     let key;
     try {
-      key = this._computeKey(message);
+      key = computeDeduplicationKey(message);
     } catch (e) {
       return {
         ok: false,
@@ -67,31 +185,25 @@ export default class DuplicateDetector {
       };
     }
 
-    const expireAt = this._chooseExpiration(message);
-    const wasAdded = await this.persistedHashes.add(key, expireAt);
+    const hash = truncatedHash(key);
+    const expireAt = this._chooseExpiration();
+    const wasAdded = await this.persistedHashes.add(hash, expireAt);
     if (!wasAdded) {
       return {
         ok: false,
-        rejectReason: `Key has been already seen (key: ${key})`,
+        rejectReason: `Hash for the deduplication key has been already seen (key: ${key}, hash: ${hash})`,
       };
     }
     return {
       ok: true,
       rollback: async () => {
         try {
-          await this.persistedHashes.delete(key);
+          await this.persistedHashes.delete(hash);
         } catch (e) {
           logger.warn('Failed to rollback. Message cannot be resent.', e);
         }
       },
     };
-  }
-
-  _computeKey(message) {
-    function notFound() {
-      throw new Error(`Unknown message type: ${message.action}`);
-    }
-    return (KEY_COMPUTATION[message.action] || notFound)(message);
   }
 
   _chooseExpiration() {

--- a/modules/human-web-lite/sources/search-extractor.es
+++ b/modules/human-web-lite/sources/search-extractor.es
@@ -34,8 +34,8 @@ const HOUR = 60 * 60 * 1000;
  * living in timezones like US west coast where UTC midnight
  * happens during the day. Without a minimum cooldown, there is
  * the risk of introducing bias in the collected data, as we
- * would include researches with higher likelihood than in
- * other parts of the world (e.g. Europe).
+ * would include repeated searches with higher likelihood than
+ * in other parts of the world (e.g. Europe).
  */
 function chooseExpiration() {
   const minCooldown = 8 * HOUR;
@@ -260,7 +260,9 @@ export default class SearchExtractor {
           payload[key] = context[key] ?? null;
         }
       }
-      messages.push({
+
+      const { deduplicateBy } = schema;
+      const body = {
         type: 'humanweb',
         action,
         payload,
@@ -268,7 +270,8 @@ export default class SearchExtractor {
         channel: this.channel,
         ts: getTimeAsYYYYMMDD(),
         'anti-duplicates': Math.floor(random() * 10000000),
-      });
+      };
+      messages.push({ body, deduplicateBy });
     }
     return messages;
   }

--- a/modules/human-web-lite/tests/unit/duplicate-detector-test.es
+++ b/modules/human-web-lite/tests/unit/duplicate-detector-test.es
@@ -1,0 +1,607 @@
+/*!
+ * Copyright (c) 2014-present Cliqz GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/* global chai, describeModule */
+
+const expect = chai.expect;
+
+function getUniqueId() {
+  getUniqueId.uniqueId = (getUniqueId.uniqueId || 0) + 1;
+  return getUniqueId.uniqueId;
+}
+
+/* eslint-disable no-param-reassign */
+function mkMessage({ action = 'test-action', payload, deduplicateBy } = {}) {
+  payload = payload || {
+    testFieldWithSeq: `test-field-${getUniqueId()}`,
+  };
+
+  const body = {
+    type: 'test-type',
+    action,
+    payload,
+    ver: '2.9',
+    channel: 'test-channel',
+    ts: 20220101,
+    'anti-duplicates': 1,
+  };
+  return { body, deduplicateBy };
+}
+
+export default describeModule('human-web-lite/duplicate-detector',
+  () => ({
+    'platform/globals': {
+      default: {}
+    },
+    'core/crypto/random': {
+      default: Math.random.bind(Math),
+    },
+  }),
+  () => {
+    describe('#DuplicateDetector', function () {
+      let uut;
+      let persistedHashes;
+
+      beforeEach(async function () {
+        // in-memory implementation of storage
+        const MemoryPersistentMap = (await this.system.import('core/helpers/memory-map')).default;
+        const storage = new MemoryPersistentMap();
+
+        const PersistedHashes = (await this.system.import('hpn-lite/persisted-hashes')).default;
+        persistedHashes = new PersistedHashes({ storage, storageKey: 'dummy-storage-key' });
+
+        const DuplicateDetector = this.module().default;
+        uut = new DuplicateDetector(persistedHashes);
+      });
+
+      afterEach(() => {
+        uut.unload();
+        uut = null;
+      });
+
+      async function expectSendOK(msg) {
+        const result = await uut.trySend(msg);
+        expect(result.ok).to.be.true;
+        expect(result.rollback).to.be.a('function');
+        return result;
+      }
+
+      async function expectSendNotOK(msg) {
+        const result = await uut.trySend(msg);
+        expect(result.ok).to.be.false;
+        expect(result.rejectReason).to.be.a('string').that.is.not.empty;
+        return result;
+      }
+
+      it('should accept a valid message', async function () {
+        await expectSendOK(mkMessage());
+      });
+
+      it('should not accept the same message twice (one arriving after the other)', async function () {
+        const msg = mkMessage();
+        await expectSendOK(msg);
+        await expectSendNotOK(msg);
+        await expectSendNotOK(msg);
+      });
+
+      it('should not accept the same message twice (both arriving at the same time)', async function () {
+        const msg = mkMessage();
+        const result = await Promise.all([uut.trySend(msg), uut.trySend(msg), uut.trySend(msg)]);
+        expect(result.map(x => x.ok).sort()).to.eql([false, false, true]); // exactly one succeeds
+      });
+
+      it('should allow to send it again after rolling back', async function () {
+        const msg = mkMessage();
+        const { rollback } = await expectSendOK(msg);
+
+        await expectSendNotOK(msg); // duplicate
+        rollback();
+        await expectSendOK(msg);
+      });
+
+      it('should detect duplicated messages even keys differ, but ignore non-key fields', async function () {
+        const q = 'some key shared in both messages';
+        const deduplicateBy = 'q';
+
+        await expectSendOK(mkMessage({
+          payload: {
+            q,
+            nonKey: 'This is not part of the key',
+          },
+          deduplicateBy, // but ignore "nonKey"
+        }));
+
+        await expectSendNotOK(mkMessage({
+          payload: {
+            q,
+            nonKey: 'This is a different text, but it is a duplicate nevertheless',
+          },
+          deduplicateBy,
+        }));
+
+        await expectSendOK(mkMessage({
+          payload: {
+            q: 'another key, so it no longer a duplicate',
+            nonKey: 'This is not part of the key',
+          },
+          deduplicateBy,
+        }));
+      });
+    });
+
+    describe('#computeDeduplicationKey', function () {
+      let computeDeduplicationKey;
+
+      beforeEach(function () {
+        computeDeduplicationKey = this.module().computeDeduplicationKey;
+      });
+
+      function computeKeysForPayload(payload1, payload2, by) {
+        const action = 'action';
+        const ts = '20220923';
+        const deduplicateBy = by;
+        const key1 = computeDeduplicationKey({
+          body: {
+            action,
+            payload: payload1,
+            ts,
+          },
+          deduplicateBy
+        });
+        expect(key1).to.be.a('string').that.is.not.empty;
+
+        const key2 = computeDeduplicationKey({
+          body: {
+            action,
+            payload: payload2,
+            ts,
+          },
+          deduplicateBy
+        });
+        expect(key2).to.be.a('string').that.is.not.empty;
+
+        return [key1, key2];
+      }
+
+      function duplicatedPayload(payload1, payload2, by) {
+        const [key1, key2] = computeKeysForPayload(payload1, payload2, by);
+        if (key1 !== key2) {
+          chai.expect.fail([
+            `The following two payloads should have been detected as duplicates (key fields=<${by}>):`,
+            JSON.stringify(payload1, null, 2),
+            JSON.stringify(payload2, null, 2),
+            'but their computed keys differ:',
+            key1,
+            '!=',
+            key2,
+          ].join('\n'));
+        }
+      }
+
+      function nonDuplicatedPayload(payload1, payload2, by) {
+        const [key1, key2] = computeKeysForPayload(payload1, payload2, by);
+        if (key1 === key2) {
+          chai.expect.fail([
+            `The following two payloads should not have been detected as duplicates (key fields=<${by}>):`,
+            JSON.stringify(payload1, null, 2),
+            JSON.stringify(payload2, null, 2),
+            `but their computed key is the same: ${key1}`,
+          ].join('\n'));
+        }
+      }
+
+      it('should differ iff any part of the <action, timestamp, key fields> tuple differs', function () {
+        const seen = new Set();
+        for (const action of ['action1', 'action2']) {
+          for (const ts of ['20010101', '20020202']) {
+            for (const key of ['key1', 'key2']) {
+              const dedupHash = computeDeduplicationKey({
+                body: {
+                  action,
+                  payload: {
+                    key,
+                  },
+                  ts,
+                },
+              });
+              expect(seen.has(dedupHash)).to.be.false;
+              seen.add(dedupHash);
+            }
+          }
+        }
+      });
+
+      it('should extract the full payload by default', function () {
+        for (const deduplicateBy of ['', undefined, null]) {
+          expect(computeDeduplicationKey({
+            body: {
+              action: 'action',
+              payload: {
+                x: 'x42x',
+                y: 'y42y',
+              },
+              ts: '20220923',
+            },
+            deduplicateBy,
+          })).to.be.a('string').that.includes('x42x').and.includes('y42y');
+        }
+      });
+
+      it('should detect consider only key fields', function () {
+        duplicatedPayload({
+          x: 'x',
+          y: 'y',
+          foo: 42,
+        }, {
+          x: 'x',
+          y: 'y',
+          bar: 42,
+        }, 'x,y');
+
+        for (const by of ['x,y,foo', 'x,y,bar', '']) {
+          nonDuplicatedPayload({
+            x: 'x',
+            y: 'y',
+            foo: 42,
+          }, {
+            x: 'x',
+            y: 'y',
+            bar: 42,
+          }, by);
+        }
+      });
+
+      it('should supported nested keys', function () {
+        duplicatedPayload({
+          x: 'x',
+          y: {
+            z: 'z',
+          },
+        }, {
+          x: 'x',
+          y: {
+            z: 'z',
+          },
+          ignore: 'not part of key',
+        }, 'x,y');
+
+        duplicatedPayload({
+          x: 'x',
+          y: {
+            z: 'z',
+          },
+        }, {
+          x: 'x',
+          y: {
+            z: 'z',
+          },
+          ignore: 'not part of key',
+        }, 'x,y.z');
+      });
+
+      it('should match whole objects if the path leads to an object or array', function () {
+        nonDuplicatedPayload({
+          x: 'x',
+          y: {
+            z: 'z',
+          },
+        }, {
+          x: 'x',
+          y: {
+            z: 'z',
+            inner: 'part of key',
+          },
+          ignore: 'not part of key',
+        }, 'x,y');
+
+        duplicatedPayload({
+          x: 'x',
+          y: {
+            z: {
+              bar: { baz: 42 },
+              foo: [1, 2, 3],
+            },
+          },
+        }, {
+          x: 'x',
+          y: {
+            z: {
+              bar: { baz: 42 },
+              foo: [1, 2, 3],
+            },
+          },
+          ignore: 'not part of key',
+        }, 'x,y');
+      });
+
+      it('should handle arrays', function () {
+        nonDuplicatedPayload({
+          x: [1.23]
+        }, {
+          x: [0],
+        }, 'x');
+
+        duplicatedPayload({
+          x: [1.23],
+          y: {
+            z: [false, true],
+          },
+        }, {
+          x: [1.23],
+          y: {
+            z: [false, true],
+          },
+        }, 'y.z');
+
+        duplicatedPayload({
+          x: [1.23],
+          y: {
+            z: [false, true],
+            ignore: 'some text',
+          },
+        }, {
+          x: [1.23],
+          y: {
+            z: [false, true],
+            ignore: 'another text',
+          },
+        }, 'x,y.z');
+
+        nonDuplicatedPayload({
+          y: {
+            z: [false],
+          },
+        }, {
+          y: {
+            z: [true],
+          },
+        }, 'y.z');
+      });
+
+      it('should ignore the order of fields (non-nested)', function () {
+        duplicatedPayload({
+          x: 'x',
+          y: 'y',
+        }, {
+          y: 'y',
+          x: 'x',
+        });
+        duplicatedPayload({
+          x: 'x',
+          y: 'y',
+        }, {
+          y: 'y',
+          x: 'x',
+        }, 'x,y');
+        duplicatedPayload({
+          x: 'x',
+          y: 'y',
+        }, {
+          y: 'y',
+          x: 'x',
+        }, 'y,x');
+      });
+
+      it('should ignore the order of fields (nested)', function () {
+        duplicatedPayload({
+          x: 'x',
+          y: 'y',
+          z: {
+            arr: [
+              {
+                x: 42.1,
+                y: [1, 2, 3],
+                z: undefined,
+              },
+              {
+                x: [1, 2, 3],
+                y: 42,
+                z: null,
+              },
+            ],
+            foo: 42,
+            bar: 'baz',
+            yes: true,
+            no: false,
+          },
+        }, {
+          y: 'y',
+          z: {
+            bar: 'baz',
+            no: false,
+            yes: true,
+            foo: 42,
+            arr: [
+              {
+                z: undefined,
+                y: [1, 2, 3],
+                x: 42.1,
+              },
+              {
+                y: [1, 2, 3],
+                z: null,
+                x: 42,
+              },
+            ],
+          },
+          x: 'x',
+        }, 'y,x');
+      });
+
+      it('should expand arrays while matching', function () {
+        duplicatedPayload({
+          foo: [
+            [{ x: 1, y: 2, z: 3 }],
+          ],
+        }, {
+          foo: [
+            [{ x: 1, y: 2, z: 3 }],
+          ],
+        }, 'foo.[].x,foo.[].y,foo.[].z');
+
+        duplicatedPayload({
+          foo: [
+            [{ x: 1, y: 2 }],
+          ],
+        }, {
+          foo: [
+            [{ x: 1, y: 2, z: 3 }],
+          ],
+        }, 'foo.[].x,foo.[].y');
+
+        nonDuplicatedPayload({
+          foo: [
+            [{ x: 1, y: 2, z: 3 }],
+          ],
+        }, {
+          foo: [
+            [{ x: 1, y: 2, z: 3 }],
+            [{ x: 1, y: 2, z: 3 }],
+          ],
+        }, 'foo.[].[].x');
+
+        duplicatedPayload({
+          foo: [
+            [{ x: 1, y: 1 }],
+          ],
+        }, {
+          foo: [
+            [{ x: 1, y: 2 }],
+          ],
+        }, 'foo.[].[].x');
+
+        nonDuplicatedPayload({
+          foo: [
+            [{ x: 1, y: 1 }],
+          ],
+        }, {
+          foo: [
+            [{ x: 1, y: 2 }],
+          ],
+        }, 'foo.[].[].x,foo.[].[].y');
+      });
+
+      it('should only consider real matches when expanding arrays', function () {
+        duplicatedPayload({
+          x: [
+            [{ y: [] }]
+          ],
+        }, {
+          foo: [
+          ],
+        }, 'x.[].y.[].z');
+      });
+
+      it('should support matching array indices', function () {
+        duplicatedPayload({
+          x: [
+            { y: 'part of key' },
+            { y: 'some text not part of index' },
+          ],
+        }, {
+          x: [
+            { y: 'part of key' },
+            { y: 'another text not part of index' },
+          ],
+        }, 'x.0.y');
+
+        nonDuplicatedPayload({
+          x: [
+            { y: 'part of key' },
+            { y: 'some text part of index' },
+          ],
+        }, {
+          x: [
+            { y: 'part of key' },
+            { y: 'another text part of index' },
+          ],
+        }, 'x.[].y');
+
+        duplicatedPayload({
+          x: [
+            [
+              { y: 'part of key' },
+              { y: 'some text not part of index' },
+            ],
+          ],
+        }, {
+          x: [
+            [
+              { y: 'part of key' },
+              { y: 'another text not part of index' },
+            ],
+          ],
+        }, 'x.0.0.y');
+      });
+
+      // (Mostly for documentation; we are not relying on the following semantic)
+      //
+      // JavaScripts's null and undefined will be both treated as missing values.
+      // In our context, that is reasonable and avoiding it is hard anyway because
+      // details of JSON (which is used in the communication layer) will shine through:
+      // JSON.stringify([undefined]) === JSON.stringify([null])
+      //
+      // If changes of the implementation break this tests, feel free to change it.
+      // It documents the status-quo of the implemenation, but everything here
+      it('should treat null and undefined both as missing value', function () {
+        duplicatedPayload({
+          x: null,
+          y: 'foo'
+        }, {
+          x: undefined,
+          y: 'foo'
+        }, 'x,y');
+        duplicatedPayload({
+          x: null,
+          y: 'foo'
+        }, {
+          y: 'foo'
+        }, 'x,y');
+        duplicatedPayload({
+          x: undefined,
+          y: 'foo'
+        }, {
+          y: 'foo'
+        }, 'x,y');
+        duplicatedPayload({
+          y: 'foo'
+        }, {
+          y: 'foo'
+        }, 'x,y');
+
+        // When matching without explicit keys, there are three case:
+        // null, undefined and omitted. For technical reasons, we cannot
+        // easily merge omitted with the other two. It should not be important,
+        // so we can accept the following behavior:
+        duplicatedPayload({
+          x: null,
+          y: 'foo'
+        }, {
+          x: undefined,
+          y: 'foo'
+        });
+        nonDuplicatedPayload({
+          x: null,
+          y: 'foo'
+        }, {
+          y: 'foo'
+        });
+        nonDuplicatedPayload({
+          x: undefined,
+          y: 'foo'
+        }, {
+          y: 'foo'
+        });
+        duplicatedPayload({
+          y: 'foo'
+        }, {
+          y: 'foo'
+        });
+      });
+    });
+  });

--- a/modules/human-web-lite/tests/unit/search-extractor-test.es
+++ b/modules/human-web-lite/tests/unit/search-extractor-test.es
@@ -103,6 +103,7 @@ const ANDROID_PATTERNS = {
           { key: 'qurl' },
           { key: 'ctry' },
         ],
+        deduplicateBy: 'q',
       },
     },
   },
@@ -145,6 +146,7 @@ const IOS_PATTERNS = {
           { key: 'qurl' },
           { key: 'ctry' },
         ],
+        deduplicateBy: 'q',
       },
     },
   },
@@ -205,8 +207,8 @@ export default describeModule('human-web-lite/search-extractor',
           const verifyFixtureExpectations = function (results) {
             // group messages by action
             const messages = {};
-            results.forEach((msg) => { messages[msg.action] = []; });
-            results.forEach((msg) => { messages[msg.action].push(msg); });
+            results.forEach((msg) => { messages[msg.body.action] = []; });
+            results.forEach((msg) => { messages[msg.body.action].push(msg.body); });
 
             // uncomment to export expectations:
             /* eslint-disable-next-line max-len */


### PR DESCRIPTION
Instead of hard-coding the rules, the logic how to detect duplicated messages in the client can be configured now in the "deduplicateBy" field in the pattern DSL.