### PR TITLE
Adblocker: url matched against engine should be lower cased

### DIFF
--- a/modules/adblocker/sources/adblocker.es
+++ b/modules/adblocker/sources/adblocker.es
@@ -42,7 +42,7 @@ function makeRequestFromContext(url, urlParts, {
 
     domain: urlParts.generalDomain || '',
     hostname: urlParts.hostname || '',
-    url,
+    url: url.toLowerCase(),
 
     // In case of a 'sub_frame' request, the partiness for the adblocker needs to
     // be slightly different. Since it's possible that `url` and `frameUrl` are


### PR DESCRIPTION
fix https://github.com/ghostery/broken-page-reports/issues/57

as this is done here https://github.com/ghostery/adblocker/blob/b99780705bde71734be6f768b27baa5cc39ce685/packages/adblocker/src/request.ts#L255