### PR TITLE
Fix patterns updater on Android

### DIFF
--- a/modules/human-web-lite/sources/patterns-updater.es
+++ b/modules/human-web-lite/sources/patterns-updater.es
@@ -196,6 +196,7 @@ export default class PatternsUpdater {
       const url = this.patternUpdateUrl;
       const response = await this._fetch(url, {
         method: 'GET',
+        cache: 'no-cache',
         credentials: 'omit',
       });
       if (!response.ok) {

--- a/modules/human-web-lite/sources/patterns-updater.es
+++ b/modules/human-web-lite/sources/patterns-updater.es
@@ -113,7 +113,7 @@ export default class PatternsUpdater {
     let force = false;
     try {
       let persistedState = await this.storage.get(this.storageKey);
-      if (persistedState && persistedState.version !== DB_VERSION) {
+      if (persistedState && persistedState.dbVersion !== DB_VERSION) {
         logger.info('DB_VERSION changed. Discarding the cache...');
         persistedState = null;
       }

--- a/modules/human-web-lite/tests/unit/patterns-updater-test.es
+++ b/modules/human-web-lite/tests/unit/patterns-updater-test.es
@@ -62,6 +62,7 @@ function mockFetch(patternsUrl, serverPatterns) {
     url: patternsUrl,
     options: {
       method: 'GET',
+      cache: 'no-cache',
       credentials: 'omit',
     },
   };

--- a/modules/human-web-lite/tests/unit/patterns-updater-test.es
+++ b/modules/human-web-lite/tests/unit/patterns-updater-test.es
@@ -132,6 +132,7 @@ export default describeModule('human-web-lite/patterns-updater',
   }),
   () => {
     describe('#PatternsUpdater', function () {
+      const storageKey = 'some-storage-key';
       let PatternsUpdater;
       let uut;
       let config;
@@ -172,6 +173,22 @@ export default describeModule('human-web-lite/patterns-updater',
         expect(clientPatterns.getRulesSnapshot()).to.deep.equal(expectedRules);
       }
 
+      function newPatternsUpdater() {
+        return new PatternsUpdater({
+          config,
+          patterns: clientPatterns,
+          storage,
+          storageKey,
+          _fetchImpl: (...args) => fetchMock.fetchImpl(...args),
+        });
+      }
+
+      // Helper that simulate an event like a restart of the service worker/background script:
+      // it keeps the storage but purges/ everything that was in memory.
+      async function simulateRestart() {
+        uut = newPatternsUpdater();
+      }
+
       beforeEach(function () {
         PatternsUpdater = this.module().default;
         clientPatterns = mockPatterns();
@@ -182,16 +199,9 @@ export default describeModule('human-web-lite/patterns-updater',
         config = {
           HUMAN_WEB_LITE_PATTERNS: 'https://patterns-location.test',
         };
-        const storageKey = 'some-storage-key';
         storage = mockStorage(storageKey);
         fetchMock = mockFetch(config.HUMAN_WEB_LITE_PATTERNS, serverPatterns);
-        uut = new PatternsUpdater({
-          config,
-          patterns: clientPatterns,
-          storage,
-          storageKey,
-          _fetchImpl: (...args) => fetchMock.fetchImpl(...args),
-        });
+        uut = newPatternsUpdater();
       });
 
       describe('on a fresh extension installation', function () {
@@ -344,7 +354,40 @@ export default describeModule('human-web-lite/patterns-updater',
             expect(fetchMock.stats.attemptedRequests).to.equal(2);
           });
         });
+
+        describe('[after a restart]', function () {
+          it('should not immediately fetch patterns again', async () => {
+            // first make sure the patterns are loaded
+            const now = Date.now();
+            releasePatterns(SOME_NON_EMPTY_PATTERN);
+            await uut.init({ now });
+            expectLoadedPatternsToBe(SOME_NON_EMPTY_PATTERN);
+            expect(fetchMock.stats.attemptedRequests).to.equal(1);
+
+            // If we restart now without letting much time pass, it should
+            // trust the persisted value and save the network calls.
+            await simulateRestart();
+            expect(fetchMock.stats.attemptedRequests).to.equal(1);
+            await uut.init({ now: now + 10 * SECOND });
+            expect(fetchMock.stats.attemptedRequests).to.equal(1);
+          });
+
+          it('should eventually fetch patterns if enough time passed', async () => {
+            // first make sure the patterns are loaded
+            const now = Date.now();
+            releasePatterns(SOME_NON_EMPTY_PATTERN);
+            await uut.init({ now });
+            expectLoadedPatternsToBe(SOME_NON_EMPTY_PATTERN);
+            expect(fetchMock.stats.attemptedRequests).to.equal(1);
+
+            // If we restart now after a longer time, it should not
+            // trust the cached patterns but fetch them from the server.
+            await simulateRestart();
+            expect(fetchMock.stats.attemptedRequests).to.equal(1);
+            await uut.init({ now: now + 4 * WEEK });
+            expect(fetchMock.stats.attemptedRequests).to.equal(2);
+          });
+        });
       });
     });
   });
-


### PR DESCRIPTION
* fixed: it is important to bypass the cache when updating
* fixed: loading the persisted state didn't work