### PR TITLE
Fixed exception in quorum check

### DIFF
--- a/modules/human-web/sources/human-web.es
+++ b/modules/human-web/sources/human-web.es
@@ -3244,7 +3244,7 @@ const CliqzHumanWeb = {
       }
 
       _log("Perform QC: quorum confirmation required");
-      return CliqzHumanWeb._quorumCheckAnyString(msg.payload);
+      return CliqzHumanWeb._quorumCheckAnyString(msg.payload.url);
     },
 
     async _quorumCheckAnyString(str) {


### PR DESCRIPTION
Fixed: when page messages ask for quorum, the hash should be computed from the URL not the payload.
Trying to hash the object will fail and messages will be mistakenly dropped.

The regression was introduced in https://github.com/ghostery/common/pull/35/