### PR TITLE
Core: remove obsolete window observers

### DIFF
--- a/modules/core/sources/services/telemetry.es
+++ b/modules/core/sources/services/telemetry.es
@@ -8,7 +8,6 @@
 
 import prefs from '../prefs';
 import { subscribe } from '../events';
-import { isPrivateMode, getWindow } from '../browser';
 import inject from '../kord/inject';
 import EventEmitter from '../event-emitter';
 import Logger from '../logger';
@@ -211,20 +210,6 @@ export async function service(app) {
       if (!enabled) {
         // Telemetry is currently disabled (opted-out)
         logger.log('Could not push telemetry: disabled.', schemaName, payload);
-        return Promise.resolve();
-      }
-
-      // IMPORTANT: This check is only an approximation of the expected
-      // behavior. The window returned by `getWindow` is only the currently
-      // focused window. This means that if a private window is open in the
-      // background and that telemetry is sent from it then `isPrivateMode` will
-      // return false. Ideally each caller of telemetry should make sure that if
-      // a window is available, the check is performed before calling
-      // `telemetry.push`. The following check is simply a fallback, to catch as
-      // many cases as possible (although it is not bullet-proof).
-      const currentWindow = getWindow();
-      if (currentWindow && isPrivateMode(currentWindow)) {
-        logger.log('Could not push telemetry: private window.', schemaName, payload);
         return Promise.resolve();
       }
 

--- a/modules/core/tests/unit/app-test.es
+++ b/modules/core/tests/unit/app-test.es
@@ -89,9 +89,6 @@ export default describeModule('core/app',
       'platform/globals': {
         chrome: {},
       },
-      'platform/browser': {
-        forEachWindow() {},
-      },
       'core/platform': {
         default: {},
       },

--- a/modules/human-web/sources/human-web.es
+++ b/modules/human-web/sources/human-web.es
@@ -18,7 +18,7 @@ import Storage from '../platform/human-web/storage';
 import config from '../core/config';
 import { getAllOpenPages } from '../platform/human-web/opentabs';
 import { normalizeAclkUrl } from './ad-detection';
-import { getActiveTab, isPrivateMode, getWindow } from '../core/browser';
+import { getActiveTab } from '../core/browser';
 import DoublefetchHandler from './doublefetch-handler';
 import ContentExtractionPatternsLoader from './content-extraction-patterns-loader';
 import HumanWebPatternsLoader from './human-web-patterns-loader';
@@ -2393,9 +2393,6 @@ const CliqzHumanWeb = {
       if (!CliqzHumanWeb || //might be called after the module gets unloaded
           prefs.get('humanWebOptOut', false)) {
         return discard('human web disabled');
-      }
-      if (isPrivateMode(getWindow())) {
-        return discard('private mode');
       }
 
       // Sanitize message before doing the quorum check.

--- a/modules/integration-tests/sources/background.es
+++ b/modules/integration-tests/sources/background.es
@@ -13,9 +13,6 @@ import sleep from '../core/helpers/sleep';
 import getTestUrl from '../platform/integration-tests/test-launcher';
 import {
   getActiveTab,
-  addWindowObserver,
-  removeWindowObserver,
-  forEachWindow,
 } from '../platform/browser';
 import { browser } from '../platform/globals';
 import { newTab } from '../platform/tabs';
@@ -59,13 +56,12 @@ export default {
     };
     browser.runtime.onMessage.addListener(this.mixextlogListener);
 
-    forEachWindow(() => this.startTestsWhenExtensionLoaded());
+    this.startTestsWhenExtensionLoaded();
     this.windowObserver = (w, topic) => {
       if (topic === 'opened') {
         this.startTestsWhenExtensionLoaded();
       }
     };
-    addWindowObserver(this.windowObserver);
   },
 
   unload() {
@@ -73,7 +69,6 @@ export default {
     if (this.logChannel) {
       this.logChannel.close();
     }
-    removeWindowObserver(this.windowObserver);
   },
 
   async startTestsWhenExtensionLoaded() {

--- a/platforms/node/browser.es
+++ b/platforms/node/browser.es
@@ -20,16 +20,7 @@ export function checkIsWindowActive() {
   return Promise.resolve(true);
 }
 
-export function forEachWindow() {
-}
-
 export function setOurOwnPrefs() {
-}
-
-export function addWindowObserver() {
-}
-
-export function removeWindowObserver() {
 }
 
 export function addSessionRestoreObserver() {
@@ -62,8 +53,4 @@ export function getCookies() {
 
 export function isDefaultBrowser() {
   return Promise.resolve(null);
-}
-
-export function isPrivateMode() {
-  return false;
 }

--- a/platforms/react-native/browser.es
+++ b/platforms/react-native/browser.es
@@ -7,7 +7,6 @@
  */
 
 import { NativeModules } from 'react-native';
-import window from './window';
 
 const nativeWebRequest = NativeModules.WebRequest;
 const LocaleConstants = NativeModules.LocaleConstants;

--- a/platforms/react-native/browser.es
+++ b/platforms/react-native/browser.es
@@ -36,16 +36,6 @@ export function checkIsWindowActive(windowID) {
   return nativeWebRequest.isWindowActive(parseInt(windowID, 10));
 }
 
-export function forEachWindow(cb) {
-  cb(window);
-}
-
-export function addWindowObserver() {
-}
-
-export function removeWindowObserver() {
-}
-
 export function addSessionRestoreObserver() {
 }
 
@@ -78,10 +68,6 @@ export function getCookies() {
 
 export function isDefaultBrowser() {
   return null;
-}
-
-export function isPrivateMode() {
-  return false;
 }
 
 export function openLink() {

--- a/platforms/webextension/browser.es
+++ b/platforms/webextension/browser.es
@@ -7,17 +7,11 @@
  */
 
 import { window, chrome, browser } from './globals';
-import windows from './windows';
 
 export * from './tabs';
-export * from './windows';
 
-let currentWindow = null;
 const windowsMap = new Map();
 
-export function getWindow() {
-  return currentWindow;
-}
 
 export function isTabURL() {
   return false;
@@ -40,77 +34,11 @@ export function getBrowserMajorVersion() {
   return majorVer;
 }
 
-const windowObservers = new WeakMap();
-
-export function addWindowObserver(fn) {
-  if (windows === undefined) {
-    return;
-  }
-  const observer = {
-    open: win => fn(win, 'opened'),
-    focus: (windowId) => {
-      const win = windowsMap.get(windowId) || { id: windowId };
-      return fn(win, 'focused');
-    },
-    close: windowId => fn({ id: windowId }, 'closed'),
-  };
-  windowObservers.set(fn, observer);
-  windows.onCreated.addListener(observer.open);
-  windows.onFocusChanged.addListener(observer.focus);
-  windows.onRemoved.addListener(observer.close);
-}
-
-export function removeWindowObserver(fn) {
-  if (windows === undefined) {
-    return;
-  }
-  const observer = windowObservers.get(fn);
-  windows.onCreated.removeListener(observer.open);
-  windows.onFocusChanged.removeListener(observer.focus);
-  windows.onRemoved.removeListener(observer.close);
-}
-
 export function addSessionRestoreObserver() {}
 export function removeSessionRestoreObserver() {}
 
-function windowObserver(win, event) {
-  if (event === 'opened') {
-    windowsMap.set(win.id, win);
-  }
-  if (event === 'closed') {
-    windowsMap.delete(win.id);
-  }
-  if (event === 'focused') {
-    currentWindow = windowsMap.get(win.id) || currentWindow;
-  }
-  if (win.focused) {
-    currentWindow = win;
-  }
-}
-
-if (windows !== undefined) {
-  addWindowObserver(windowObserver);
-  windows.getAll(
-    wins => wins.forEach(win => windowObserver(win, 'opened'))
-  );
-} else {
-  currentWindow = window;
-  windowsMap.set(undefined, window);
-}
-
 export function addMigrationObserver() {}
 export function removeMigrationObserver() {}
-export function forEachWindow(fn) {
-  return [...windowsMap.values()].map((win) => {
-    let ret;
-    try {
-      ret = fn(win);
-    } catch (e) {
-      //
-    }
-    return ret;
-  });
-}
 
 export function getUrlForTab(tabId) {
   return new Promise((resolve) => {
@@ -168,13 +96,6 @@ export function isDefaultBrowser() {
   }
 
   return Promise.resolve(null);
-}
-
-export function isPrivateMode(win) {
-  if (!win) {
-    throw new Error('isPrivateMode was called without a window object');
-  }
-  return win.incognito || chrome.extension.inIncognitoContext;
 }
 
 export function openLink(win, url, newTab = false, active = true, isPrivate = false) {

--- a/platforms/webextension/browser.es
+++ b/platforms/webextension/browser.es
@@ -10,9 +10,6 @@ import { window, chrome, browser } from './globals';
 
 export * from './tabs';
 
-const windowsMap = new Map();
-
-
 export function isTabURL() {
   return false;
 }


### PR DESCRIPTION
Comming probably from Firefox Boostrap extension days, the windows observers where not used correctly - as sometimes they were looking of chrome.windows object and sometimes on the extension background window (depending on the extension access to chrome.windows).

Additionaly, those were the subject of the race condition in case browser was starting in the backround.

The only current usecase was to check if the browser runs in incognito mode, but even that was not correct as all modules should do the check based on chrome.tabs, chrome.webNavigation or chrome.webRequest and prevent any processing if incognito mode was detected. Which is very much the case.

This all makes this code safe to be removed.